### PR TITLE
Threshold Graph Bugfix

### DIFF
--- a/R/misc.r
+++ b/R/misc.r
@@ -39,7 +39,7 @@ recode.matrix <- function(data, ...) {
 
   # Checking the size of the matrix
   dn <- dimnames(data)
-  data <- as.factor(as.character(as.vector(data)))
+  data <- as.factor(as.vector(data)) # Petar & Kristina changed as.factor(as.character(as.vector(data)))
   n <- length(data)
   output <- cbind(data[1:(n/2)], data[(n/2+1):n])
   data <- unique(data)


### PR DESCRIPTION
### Description
Issue was first identified with incorrect node labeling for graphs in the threshold function. The graphs were being assigned ID numbers based on the order they appeared in the output, not based on their internal ID number. 

### Solution
Upon debugging the threshold function we were able to determine it does work as intended. Solution to threshold graphing problem was determined to be a result of the as.factor function assigning levels to integers as characters in non numerically sorted ordered. Solution was to remove character casting in the misc.r script.